### PR TITLE
OAuth2 구현

### DIFF
--- a/src/main/java/com/example/usedTrade/member/controller/MemberController.java
+++ b/src/main/java/com/example/usedTrade/member/controller/MemberController.java
@@ -87,6 +87,8 @@ public class MemberController {
     @GetMapping("/member/myPage")
     public String myPage(Model model, Principal principal) {
 
+        logger.info("### principal: " + principal.toString());
+
         MemberDto memberDto = memberService.getInfo(principal.getName());
         logger.info("### MemberDto : " + memberDto);
         model.addAttribute("memberDto", memberDto);
@@ -124,7 +126,11 @@ public class MemberController {
     }
 
     @GetMapping("/member/change/password")
-    public String changePassword() {
+    public String changePassword(Model model, Principal principal) {
+
+        logger.info("### logined email: " + principal.getName());
+        boolean fromSocial = memberService.getFromSocial(principal.getName());
+        model.addAttribute("fromSocial", fromSocial);
 
         return "member/change_password";
     }
@@ -217,22 +223,26 @@ public class MemberController {
     }
 
     @GetMapping("/member/withdraw")
-    public String withdraw() {
+    public String withdraw(Model model, Principal principal) {
+
+        logger.info("### logined email: " + principal.getName());
+        boolean fromSocial = memberService.getFromSocial(principal.getName());
+        model.addAttribute("fromSocial", fromSocial);
+
         return "member/withdraw";
     }
 
     @PostMapping("/member/withdraw")
     public String withdrawSubmit(Model model, Principal principal, String password) {
 
-        logger.info("### passwordInput: " + password);
+        logger.info("### password: " + password);
 
         ServiceResult result = memberService.withdraw(principal.getName(), password);
-        model.addAttribute("result", result.isResult());
         if (!result.isResult()) {
             model.addAttribute("error", result.getErrorCode().getDescription());
             return "member/withdraw";
         }
 
-        return "/index";
+        return "redirect:/member/logout";
     }
 }

--- a/src/main/java/com/example/usedTrade/security/config/PrincipalDetails.java
+++ b/src/main/java/com/example/usedTrade/security/config/PrincipalDetails.java
@@ -1,0 +1,46 @@
+package com.example.usedTrade.security.config;
+
+import com.example.usedTrade.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+public class PrincipalDetails extends User implements OAuth2User{
+
+    private String email;
+    private String password;
+    private String name;
+    private Map<String, Object> attr;
+
+    // Normal Login
+    public PrincipalDetails(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.email = username;
+        this.password = password;
+    }
+
+    // OAuth2Login
+    public PrincipalDetails(String username, String password, Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attr) {
+        this(username, password, authorities);
+        this.attr = attr;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attr;
+    }
+}

--- a/src/main/java/com/example/usedTrade/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/usedTrade/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
-package com.example.usedTrade.config;
+package com.example.usedTrade.security.config;
 
 
+import com.example.usedTrade.security.service.MemberOAuth2UserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final MemberOAuth2UserDetailsService oAuth2UserDetailsService;
 
     @Bean
     public PasswordEncoder getPasswordEncoder() {
@@ -46,6 +49,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .failureHandler(getFailureHandler())   // 로그인 실패 케이스
                 .defaultSuccessUrl("/")
                 .permitAll();
+
+        http.oauth2Login()
+                    .userInfoEndpoint()
+                    .userService(oAuth2UserDetailsService)
+                .and()
+                    .defaultSuccessUrl("/");
+
 
         http.logout()
                 .logoutRequestMatcher(

--- a/src/main/java/com/example/usedTrade/security/service/MemberDetailsService.java
+++ b/src/main/java/com/example/usedTrade/security/service/MemberDetailsService.java
@@ -1,0 +1,51 @@
+package com.example.usedTrade.security.service;
+
+import com.example.usedTrade.member.entity.Member;
+import com.example.usedTrade.member.error.exception.MemberEmailNotAuthenticatedException;
+import com.example.usedTrade.member.error.exception.MemberStopUserException;
+import com.example.usedTrade.member.repository.MemberRepository;
+import com.example.usedTrade.security.config.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class MemberDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findById(username)
+                .orElseThrow(() -> new UsernameNotFoundException("회원 정보가 존재하지 않습니다."));
+
+        if (Member.MEMBER_STATUS_REQ.equals(member.getStatus())) {
+            throw new MemberEmailNotAuthenticatedException("이메일 인증이 안된 계정입니다.");
+        }
+
+        if (Member.MEMBER_STATUS_STOPPED.equals(member.getStatus())) {
+            throw new MemberStopUserException("정지된 회원입니다.");
+        }
+
+        if (Member.MEMBER_STATUS_WITHDRAW.equals(member.getStatus())) {
+            throw new MemberStopUserException("탈퇴된 회원입니다.");
+        }
+
+        PrincipalDetails userDetails = new PrincipalDetails(
+                member.getEmail(),
+                member.getPassword(),
+                member.getRoles().stream()
+                        .map(role ->
+                                new SimpleGrantedAuthority("ROLE_" + role.name()))
+                        .collect(Collectors.toSet()));
+
+        return userDetails;
+    }
+}

--- a/src/main/java/com/example/usedTrade/security/service/MemberOAuth2UserDetailsService.java
+++ b/src/main/java/com/example/usedTrade/security/service/MemberOAuth2UserDetailsService.java
@@ -1,0 +1,98 @@
+package com.example.usedTrade.security.service;
+
+import com.example.usedTrade.UsedTradeApplication;
+import com.example.usedTrade.member.entity.Member;
+import com.example.usedTrade.member.entity.MemberRole;
+import com.example.usedTrade.member.repository.MemberRepository;
+import com.example.usedTrade.security.config.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.parameters.P;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class MemberOAuth2UserDetailsService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final HttpSession httpSession;
+    private static final Logger logger =
+            LoggerFactory.getLogger(UsedTradeApplication.class);
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        logger.info("-----------------------------");
+        logger.info("userRequest: " + userRequest);
+
+        String clientName = userRequest.getClientRegistration().getClientName();
+        logger.info("clientName: " + clientName);
+        logger.info(userRequest.getAdditionalParameters().toString());
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        logger.info("-------------------");
+        oAuth2User.getAttributes().forEach((k, v) -> {
+            logger.info(k + ": " + v);
+        });
+
+        String email = null;
+        if (clientName.equals("Google")) {
+            email = oAuth2User.getAttribute("email");
+        }
+
+        logger.info("EMAIL: " + email);
+
+        Member member = saveGoogleMember(email);    // register
+        PrincipalDetails principalDetails = new PrincipalDetails(
+                member.getEmail(),
+                member.getPassword(),
+                member.getRoles().stream()
+                        .map(role ->
+                                new SimpleGrantedAuthority("ROLE_" + role.name()))
+                        .collect(Collectors.toSet()),
+                oAuth2User.getAttributes());
+//        httpSession.setAttribute("user", email);
+
+        return principalDetails;
+    }
+
+    private Member saveGoogleMember(String email) {
+        Optional<Member> optionalMember = memberRepository.findById(email);
+        if (optionalMember.isPresent()) {
+            return optionalMember.get();
+        }
+
+        Member member = Member.builder()
+                .email(email)
+                .password(BCrypt.hashpw("1111", BCrypt.gensalt()))
+                .name("Social Member")
+                .address("Social Member")
+                .address_detail("Social Member")
+                .phone("Social Member")
+                .trade_num(0)
+                .status(Member.MEMBER_STATUS_AVAILABLE)
+                .managerYn(false)
+                .fromSocial(true)
+                .regDt(LocalDateTime.now())
+                .build();
+        member.addMemberRole(MemberRole.USER);
+
+        Member savedMember = memberRepository.save(member);
+
+        return savedMember;
+    }
+}

--- a/src/main/resources/templates/member/withdraw.html
+++ b/src/main/resources/templates/member/withdraw.html
@@ -34,22 +34,27 @@
                     <a href="/member/myPage"> 회원정보 </a>
                 </td>
                 <td id="detail" rowspan="6">
-                    <form action="/member/withdraw" method="post">
-                        <div th:if="${result}">
-                            탈퇴에 성공하셨습니다
-                        </div>
-                        <div th:if="${error != null}">
-                            <p th:text="${error}">failed</p>
-                        </div>
+                    <th:block th:if="${fromSocial eq false}">
+                        <form action="/member/withdraw" method="post">
+                            <div th:if="${error != null}">
+                                <p th:text="${error}">failed</p>
+                            </div>
 
-                        <p> 탈퇴를 진행하시려면 비밀번호를 입력해주세요. </p>
-                        <div>
-                            password: <input type="password" name="password" required/>
-                        </div>
-                        <div>
-                            <button type="submit"> 탈퇴 </button>
-                        </div>
-                    </form>
+                            <p> 탈퇴를 진행하시려면 비밀번호를 입력해주세요. </p>
+                            <div>
+                                password: <input type="password" name="password" required/>
+                            </div>
+                            <div>
+                                <button type="submit"> 탈퇴 </button>
+                            </div>
+                        </form>
+                    </th:block>
+                    <th:block th:if="${fromSocial}">
+                        <p>간편 로그인한 상태입니다.</p>
+                        <form action="/member/withdraw" method="post">
+                            <button type="submit">탈퇴</button>
+                        </form>
+                    </th:block>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
일반로그인을 하기위해서 MemberService에 UserDetailsService를 구현해 loadUserByUsername()메소드를 구현한 상태.
소셜 로그인 미구현.

**TO-BE**
- MemberService에서 구현한 UserDetailsService를 MemberDetailsService 라는 새로운 전용 클래스를 만들어 해당 클래스에서 구현.
- MemberDetailsService의 loadUserByUsername()메소드에서 반환해야하는 UserDetails 타입의 객체를 새로 생성하기 위해 User클래스를 상속한  PrincipalDetails 클래스를 새로 생성.
- 소셜로그인기능을 구현하기 위해 DefaultOAuth2UserSerivce를 상속한 MemberOAuth2UserDetailsService 클래스를 생성.
- loadUser() 메소드의 반환타입인 OAuth2User 타입을 위해 User를 상속한 PrincipalDetails에 OAuth2User를 구현.
- 회원정보변경과 비밀번호 변경은 소셜로그인한 유저에게는 미제공, 탈퇴기능은 비밀번호 입력없이 제공.

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 