### PR TITLE
거래게시글 페이징 기능 구현

### DIFF
--- a/src/main/java/com/example/usedTrade/page/PageRequestDTO.java
+++ b/src/main/java/com/example/usedTrade/page/PageRequestDTO.java
@@ -1,0 +1,30 @@
+package com.example.usedTrade.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class PageRequestDTO {   //화면페이지에서 요청하는 데이터에 대한 정보
+
+    private int page;
+    private int size;
+
+    // search
+//    private String type;
+//    private String keyword;
+
+    public PageRequestDTO(){
+        this.page = 1;
+        this.size = 10;
+    }
+
+    public Pageable getPageable(){
+        return PageRequest.of(page - 1, size);
+    }
+
+}

--- a/src/main/java/com/example/usedTrade/page/PageResultDTO.java
+++ b/src/main/java/com/example/usedTrade/page/PageResultDTO.java
@@ -1,0 +1,45 @@
+package com.example.usedTrade.page;
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Data
+public class PageResultDTO<DTO, EN> {
+
+    private List<DTO> dtoList;
+
+    private int totalPage;  // page 객체에서 추출 가능
+    private int page;       // page 객체의 pageable객체에서 추출 가능
+    private int size;       // page 객체의 pageable객체에서 추출 가능
+    private int start, end;
+    private boolean prev, next;
+    private List<Integer> pageList;
+
+    //result : service에서 가져온 Page데이터, fn : 가져온 page 데이터를 가공할 Function
+    public PageResultDTO(Page<EN> result, Function<EN, DTO> fn){
+        dtoList = result.stream().map(fn).collect(Collectors.toList());
+        totalPage = result.getTotalPages();
+        makePageList(result.getPageable());
+    }
+
+    private void makePageList(Pageable pageable){
+        this.page = pageable.getPageNumber() + 1;
+        this.size = pageable.getPageSize();
+
+        int tempEnd = (int)(Math.ceil(page/10.0)) * 10; // 소수값 올림
+
+        start = tempEnd - 9;
+        prev = start > 1;
+        end = totalPage > tempEnd ? tempEnd : totalPage;
+        next = totalPage > tempEnd;
+
+        pageList = IntStream.rangeClosed(start, end)
+                .boxed().collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/usedTrade/trade/controller/ApiTradeController.java
+++ b/src/main/java/com/example/usedTrade/trade/controller/ApiTradeController.java
@@ -1,5 +1,7 @@
 package com.example.usedTrade.trade.controller;
 
+import com.example.usedTrade.page.PageRequestDTO;
+import com.example.usedTrade.page.PageResultDTO;
 import com.example.usedTrade.trade.model.TradeDto;
 import com.example.usedTrade.trade.model.TradeInput;
 import com.example.usedTrade.trade.service.TradeService;
@@ -7,12 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -35,10 +35,13 @@ public class ApiTradeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<TradeDto>> getList() {
-        List<TradeDto> dtoList = tradeService.getTradeList();
+    public ResponseEntity<PageResultDTO> getList(@RequestParam("page") int page) {
+        log.info("api getTradeList page: " + page);
 
-        return new ResponseEntity<>(dtoList, HttpStatus.OK);
+        PageResultDTO pageResultDTO =
+                tradeService.getTradeList(new PageRequestDTO(page, 5));
+
+        return new ResponseEntity<>(pageResultDTO, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/example/usedTrade/trade/controller/TradeController.java
+++ b/src/main/java/com/example/usedTrade/trade/controller/TradeController.java
@@ -1,6 +1,7 @@
 package com.example.usedTrade.trade.controller;
 
 import com.example.usedTrade.keyword.service.KeywordService;
+import com.example.usedTrade.page.PageRequestDTO;
 import com.example.usedTrade.trade.entity.TradeStatus;
 import com.example.usedTrade.trade.model.TradeInput;
 import com.example.usedTrade.trade.service.TradeService;
@@ -32,7 +33,8 @@ public class TradeController {
     }
 
     @GetMapping("/list")
-    public String getList() {
+    public String getList(PageRequestDTO pageRequestDTO) {
+        log.info("list PageRequestDto: " + pageRequestDTO.toString());
 
         return "trade/list";
     }

--- a/src/main/java/com/example/usedTrade/trade/model/TradeDto.java
+++ b/src/main/java/com/example/usedTrade/trade/model/TradeDto.java
@@ -1,6 +1,5 @@
 package com.example.usedTrade.trade.model;
 
-import com.example.usedTrade.keyword.entity.Keyword;
 import com.example.usedTrade.trade.entity.Trade;
 import com.example.usedTrade.trade.entity.TradeStatus;
 import lombok.*;
@@ -19,6 +18,7 @@ import java.util.List;
 @ToString
 public class TradeDto {
     private long id;
+    private long idx;
     private String email;
     private String title;
     private String content;

--- a/src/main/java/com/example/usedTrade/trade/repository/TradeRepository.java
+++ b/src/main/java/com/example/usedTrade/trade/repository/TradeRepository.java
@@ -1,7 +1,14 @@
 package com.example.usedTrade.trade.repository;
 
 import com.example.usedTrade.trade.entity.Trade;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+    Page<Trade> findAllByOrderByRegDtDesc(Pageable pageable);
+
+    @Query(value = "select count(id) from Trade")
+    long countAll();
 }

--- a/src/main/java/com/example/usedTrade/trade/service/TradeService.java
+++ b/src/main/java/com/example/usedTrade/trade/service/TradeService.java
@@ -1,8 +1,11 @@
 package com.example.usedTrade.trade.service;
 
+import com.example.usedTrade.page.PageRequestDTO;
+import com.example.usedTrade.page.PageResultDTO;
 import com.example.usedTrade.trade.model.TradeDto;
 import com.example.usedTrade.trade.model.TradeInput;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 public interface TradeService {
@@ -29,5 +32,5 @@ public interface TradeService {
     /**
      * 거래글 전체 조회
      */
-    List<TradeDto> getTradeList();
+    PageResultDTO getTradeList(PageRequestDTO pageRequestDTO);
 }

--- a/src/main/java/com/example/usedTrade/trade/service/impl/TradeServiceImpl.java
+++ b/src/main/java/com/example/usedTrade/trade/service/impl/TradeServiceImpl.java
@@ -5,6 +5,8 @@ import com.example.usedTrade.error.trade.exception.TradeNotFoundException;
 import com.example.usedTrade.keyword.entity.Keyword;
 import com.example.usedTrade.keyword.repository.KeywordRepository;
 import com.example.usedTrade.member.entity.Member;
+import com.example.usedTrade.page.PageRequestDTO;
+import com.example.usedTrade.page.PageResultDTO;
 import com.example.usedTrade.trade.entity.Trade;
 import com.example.usedTrade.trade.entity.TradeStatus;
 import com.example.usedTrade.trade.model.TradeDto;
@@ -13,11 +15,16 @@ import com.example.usedTrade.trade.repository.TradeRepository;
 import com.example.usedTrade.trade.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -70,10 +77,31 @@ public class TradeServiceImpl implements TradeService {
     }
 
     @Override
-    public List<TradeDto> getTradeList() {
-        List<Trade> tradeList = tradeRepository.findAll();
+    @Transactional(readOnly = true)
+    public PageResultDTO<TradeDto, Trade> getTradeList(PageRequestDTO pageRequestDTO) {
+        Pageable pageable = pageRequestDTO.getPageable();
 
-        return tradeList.stream().map(TradeDto::entityToDto).collect(Collectors.toList());
+        Page<Trade> tradeList = tradeRepository.findAllByOrderByRegDtDesc(pageable);
+
+        Function<Trade, TradeDto> fn = TradeDto::entityToDto;
+
+        int totalTradeCount = (int) tradeRepository.countAll();
+
+        PageResultDTO<TradeDto, Trade> pageResultDTO = new PageResultDTO<>(tradeList, fn);
+
+        int size = pageResultDTO.getSize();
+        int page = pageResultDTO.getPage();
+        int elements = pageResultDTO.getDtoList().size();
+
+        int idx = 0;
+        for (int i = totalTradeCount - (page - 1) * size; i > totalTradeCount - size * page; i--) {
+            pageResultDTO.getDtoList().get(idx++).setIdx(i);
+            if (i <= 1) {
+                break;
+            }
+        }
+
+        return pageResultDTO;
     }
 
     private Trade findTrade(long tradeId) {

--- a/src/main/resources/templates/trade/list.html
+++ b/src/main/resources/templates/trade/list.html
@@ -52,6 +52,20 @@
     <script>
         $(document).ready(function() {
 
+            const searchParams = new URLSearchParams(location.search);
+            var pageParam = searchParams.get("page");
+            var page = {
+                page: pageParam
+            }
+
+            if (pageParam == null) {
+                page = {
+                    page: 1
+                }
+            }
+
+            console.log("parameter: " + page);
+
             function formatTime(str) {
                 var date = new Date(str);
 
@@ -62,22 +76,28 @@
                     date.getMinutes();
             }
 
+            var url = "/api/trade";
+            if (pageParam!=null) {
+                url += "?page=";
+                url += parseInt(pageParam);
+            }
+
            $.ajax({
-               url: '/api/trade',
+               url: "/api/trade",
                method: 'GET',
-               contentType: 'application/json; charset=utf-8',
+               data: page,    // TODO
                dataType: 'json',
-               success: function(tradeList) {
-                   console.log(tradeList);
+               success: function(pageResultDto) {
+                   console.log(pageResultDto);
 
                    var tradeTableBody = $("#tradeTableBody");
                    var str = "";
 
-                   $.each(tradeList, function(idx, trade){
+                   $.each(pageResultDto.dtoList, function(index, trade){
                        console.log(trade);
 
                        str += "<tr>";
-                       str += "<td>" + trade.id + "</td>";
+                       str += "<td>" + trade.idx + "</td>";
                        str += "<td><a href='/trade/detail?tradeId=" + trade.id + "'>" + trade.title + "</a></td>";
                        str += "<td>" + trade.price + "원</td>";
                        str += "<td>" + trade.keywordList + "</td>";
@@ -87,6 +107,25 @@
 
                        tradeTableBody.html(str);
                    });
+
+                   // paging
+                   var str2 = "";
+
+                   // prev btn
+                   if (pageResultDto.prev) {
+                       str2 += "<a href='/trade/list?page=" + (pageResultDto.start - 1) + "'>Previous</a> ";
+                   }
+
+                   $.each(pageResultDto.pageList, function(index, page) {
+                       str2 += "<a href='/trade/list?page=" + page + "'>" + page + "</a> ";
+                   });
+
+                   // next btn
+                   if (pageResultDto.next) {
+                       str2 += " <a href='/trade/list?page=" + (pageResultDto.end + 1) + "'>Next</a>";
+                   }
+
+                   $(".pager").html(str2);
                },
                error: function (request, status, error) {
                    console.log(JSON.stringify(error));
@@ -102,6 +141,10 @@
 
     <div th:replace="/fragments/layout.html :: fragment-body-menu"></div>
 
+    <div>
+        <a href="/trade/register">거래글 등록</a>
+    </div>
+
     <div class="list">
         <table>
             <thead>
@@ -116,6 +159,10 @@
 
             </tbody>
         </table>
+    </div>
+
+    <div class="pager">
+
     </div>
 
 </body>

--- a/src/test/java/com/example/usedTrade/trade/repository/TradeRepositoryTest.java
+++ b/src/test/java/com/example/usedTrade/trade/repository/TradeRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.example.usedTrade.trade.repository;
+
+import com.example.usedTrade.keyword.repository.KeywordRepository;
+import com.example.usedTrade.trade.entity.Trade;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class TradeRepositoryTest {
+
+    @Autowired
+    TradeRepository tradeRepository;
+
+    @Autowired
+    KeywordRepository keywordRepository;
+
+    @Test
+    void testFindAllByOrderByRegDtDesc() {
+        // given
+        Trade trade = new Trade();
+        Trade trade2 = new Trade();
+
+        tradeRepository.save(trade);
+        tradeRepository.save(trade2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Trade> tradePageList = tradeRepository.findAllByOrderByRegDtDesc(pageable);
+
+        // then
+        assertEquals(tradePageList.getContent().size(), 2);
+    }
+
+    @Test
+    void countAll() {
+        // given
+        Trade trade = new Trade();
+        Trade trade2 = new Trade();
+
+        tradeRepository.save(trade);
+        tradeRepository.save(trade2);
+
+        // when
+        long cnt = tradeRepository.countAll();
+
+        // then
+        assertEquals(2L, cnt);
+    }
+}

--- a/src/test/java/com/example/usedTrade/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/example/usedTrade/trade/service/TradeServiceTest.java
@@ -3,6 +3,8 @@ package com.example.usedTrade.trade.service;
 import com.example.usedTrade.keyword.entity.Keyword;
 import com.example.usedTrade.keyword.repository.KeywordRepository;
 import com.example.usedTrade.member.entity.Member;
+import com.example.usedTrade.page.PageRequestDTO;
+import com.example.usedTrade.page.PageResultDTO;
 import com.example.usedTrade.trade.entity.Trade;
 import com.example.usedTrade.trade.entity.TradeStatus;
 import com.example.usedTrade.trade.model.TradeDto;
@@ -14,7 +16,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.core.parameters.P;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -173,6 +179,7 @@ class TradeServiceTest {
         Set<String> keywordSet = new HashSet<>();
         keywordSet.add("생활용품");
         keywordSet.add("전자기기");
+
         Trade trade = Trade.builder()
                 .id(2L)
                 .member(Member.builder().email("test@test.com").build())
@@ -181,10 +188,9 @@ class TradeServiceTest {
                 .price(1000)
                 .tradeStatus(TradeStatus.valueOf("SELL"))
                 .keywordList(keywordSet)
+                .regDt(LocalDateTime.now()) // 먼저 생성된 게시글
                 .build();
 
-        keywordRepository.save(Keyword.builder().keywordName("생활용품").build());
-        keywordRepository.save(Keyword.builder().keywordName("전자기기").build());
 
         Trade trade2 = Trade.builder()
                 .id(3L)
@@ -194,15 +200,23 @@ class TradeServiceTest {
                 .price(1000)
                 .tradeStatus(TradeStatus.valueOf("SELL"))
                 .keywordList(keywordSet)
+                .regDt(LocalDateTime.now().plusDays(1)) // 더 나중에 생성된 거래글
                 .build();
 
-        given(tradeRepository.findAll())
-                .willReturn(new ArrayList<>(Arrays.asList(trade, trade2)));
+        PageRequestDTO pageRequestDTO = new PageRequestDTO();   // page: 1, size: 10
+
+        keywordRepository.save(Keyword.builder().keywordName("생활용품").build());
+        keywordRepository.save(Keyword.builder().keywordName("전자기기").build());
+
+        List<Trade> tradeList = Arrays.asList(trade, trade2);
+
+        given(tradeRepository.findAllByOrderByRegDtDesc(any()))
+                .willReturn(new PageImpl<>(tradeList, pageRequestDTO.getPageable(), tradeList.size()));
 
         // when
-        List<TradeDto> tradeList = tradeService.getTradeList();
+        PageResultDTO pageResultDTO = tradeService.getTradeList(pageRequestDTO);
 
         // then
-        assertEquals(2, tradeList.size());
+        assertEquals(2, pageResultDTO.getDtoList().size());
     }
 }


### PR DESCRIPTION
### 변경사항
* 페이징 번호, 페이지당 데이터개수를 담는 PageRequestDTO 모델, 원하는 페이지의 데이터와 페이징 정보를 담는 PageResultDTO 모델 생성(책 참고)
* TradeController에서 거래글 목록 페이지를 보여주는 메소드에서 PageRequestDTO를 파라미터로 받도록 변경
* ApiTradeController에서 거래글 목록 페이지를 리턴해주는 메소드에서 원하는 page를 파라미터로 받아 해당 페이지의 PageResultDTO를 반환하도록 변경
* TradeServiceImpl 코드 변경
    * 반환할 dto list에서 각 dto 마다 idx 번호 부여
* TradeRepository 에서 페이징을 위해 모든 거래글 데이터의 개수를 반환하는 쿼리 메소드 생성(@Query 사용)

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [O] 테스트 코드
- [O] API 테스트 